### PR TITLE
Refactor Register Form to allow for better composability/modularity

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -6,6 +6,7 @@ class App extends Component {
   render() {
     return (
     <div>
+      
     </div>
     );
   };

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import './App.css';
+import RegisterPage from '../user/RegisterPage';
 import UserEditPage from '../user/UserEditPage';
 
 
@@ -7,7 +8,7 @@ class App extends Component {
   render() {
     return (
     <div>
-      <UserEditPage />
+      <RegisterPage />
     </div>
     );
   };

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,14 +1,11 @@
 import React, {Component} from 'react';
 import './App.css';
-import RegisterPage from '../user/RegisterPage';
-import UserEditPage from '../user/UserEditPage';
 
 
 class App extends Component {
   render() {
     return (
     <div>
-      <RegisterPage />
     </div>
     );
   };

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,13 +1,13 @@
 import React, {Component} from 'react';
 import './App.css';
-import SignInForm from '../user/SignInForm';
+import UserEditPage from '../user/UserEditPage';
 
 
 class App extends Component {
   render() {
     return (
     <div>
-
+      <UserEditPage />
     </div>
     );
   };

--- a/src/user/RegisterForm.css
+++ b/src/user/RegisterForm.css
@@ -1,18 +1,3 @@
-.form-component-container {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  border: .2rem solid #ececec;
-  padding: 1em;
-  width: 50%;
-  border-radius: 10px;
-}
-
-.alertStyle {
-  width: 90%;
-}
-
 .register-form {
   width: 100%;
 }

--- a/src/user/RegisterForm.css
+++ b/src/user/RegisterForm.css
@@ -3,12 +3,16 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 100%;
-}
-
-.register-form {
   border: .2rem solid #ececec;
   padding: 1em;
   width: 50%;
   border-radius: 10px;
+}
+
+.alertStyle {
+  width: 90%;
+}
+
+.register-form {
+  width: 100%;
 }

--- a/src/user/RegisterForm.js
+++ b/src/user/RegisterForm.js
@@ -19,6 +19,15 @@ class RegisterForm extends Component {
     // this.register = this.register.bind(this);
   }
 
+  componentDidMount() {
+    const {firstName, lastName, email} = this.props;
+    this.setState({
+      firstName,
+      lastName,
+      email,
+    })
+  }
+
   componentDidUpdate(prevProps, prevState) {
     const passChange = prevState.password !== this.state.password;
     const confPassChange = prevState.confirmPassword !== this.state.confirmPassword;
@@ -55,15 +64,15 @@ class RegisterForm extends Component {
         <Form className="register-form" onSubmit={this.submitHandler}>
           <Form.Group controlId="formFirstName">
             <Form.Label>First Name</Form.Label>
-            <Form.Control type="text" name="firstName" onChange={this.handleFormChange} required />
+            <Form.Control type="text" name="firstName" value={this.state.firstName} onChange={this.handleFormChange} required />
           </Form.Group>
           <Form.Group controlId="formLastName">
             <Form.Label>Last Name</Form.Label>
-            <Form.Control type="text" name="lastName" onChange={this.handleFormChange} required />
+            <Form.Control type="text" name="lastName" value={this.state.lastName} onChange={this.handleFormChange} required />
           </Form.Group>
           <Form.Group controlId="formEmail">
             <Form.Label>Email</Form.Label>
-            <Form.Control type="email" name="email" onChange={this.handleFormChange} required />
+            <Form.Control type="email" name="email" value={this.state.email} onChange={this.handleFormChange} required />
           </Form.Group>
           <Form.Group controlId="formPassword">
             <Form.Label>Password</Form.Label>
@@ -77,7 +86,7 @@ class RegisterForm extends Component {
           </Form.Group>
 
           <Button variant="primary" id="registerSubmitButton" type="submit" onClick={this.submitHandler}>
-            Submit
+            {this.props.submitButton}
           </Button>
         </Form>
     )

--- a/src/user/RegisterForm.js
+++ b/src/user/RegisterForm.js
@@ -3,8 +3,7 @@
 // The sign up form then redirects the user to their personal dashboards
 
 import React, {Component} from 'react';
-import {Form, Button, Alert} from 'react-bootstrap';
-import axios from 'axios';
+import {Form, Button} from 'react-bootstrap';
 import './RegisterForm.css';
 
 
@@ -56,15 +55,15 @@ class RegisterForm extends Component {
         <Form className="register-form" onSubmit={this.submitHandler}>
           <Form.Group controlId="formFirstName">
             <Form.Label>First Name</Form.Label>
-            <Form.Control type="text" name="firstName" value={this.props.firstName} onChange={this.handleFormChange} required />
+            <Form.Control type="text" name="firstName" onChange={this.handleFormChange} required />
           </Form.Group>
           <Form.Group controlId="formLastName">
             <Form.Label>Last Name</Form.Label>
-            <Form.Control type="text" name="lastName" value={this.props.lastName} onChange={this.handleFormChange} required />
+            <Form.Control type="text" name="lastName" onChange={this.handleFormChange} required />
           </Form.Group>
           <Form.Group controlId="formEmail">
             <Form.Label>Email</Form.Label>
-            <Form.Control type="email" name="email" value={this.props.email} onChange={this.handleFormChange} required />
+            <Form.Control type="email" name="email" onChange={this.handleFormChange} required />
           </Form.Group>
           <Form.Group controlId="formPassword">
             <Form.Label>Password</Form.Label>

--- a/src/user/RegisterForm.js
+++ b/src/user/RegisterForm.js
@@ -12,12 +12,12 @@ class RegisterForm extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {authenticated: false, errorResponse: {}};
+    this.state = {};
 
     this.submitHandler = this.submitHandler.bind(this);
     this.handleFormChange = this.handleFormChange.bind(this);
     this.passwordValidator = this.passwordValidator.bind(this);
-    this.register = this.register.bind(this);
+    // this.register = this.register.bind(this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -41,7 +41,7 @@ class RegisterForm extends Component {
       'email': this.state.email,
       'password': this.state.password,
     }
-    this.register(data);
+    this.props.onSubmission(data);
   }
 
   async register(payload) {
@@ -72,14 +72,7 @@ class RegisterForm extends Component {
 
   render() {
     return (
-      <div className="form-component-container">
         <Form className="register-form" onSubmit={this.submitHandler}>
-            {this.state.errorResponse.message && 
-            <Alert variant="danger">
-              {this.state.errorResponse.message}
-              {this.state.errorResponse.requirements && 
-                this.state.errorResponse.requirements.map((requirement, idx) => <li key={idx}>{requirement}</li>)}
-            </Alert>}
           <Form.Group controlId="formFirstName">
             <Form.Label>First Name</Form.Label>
             <Form.Control type="text" name="firstName" onChange={this.handleFormChange} required />
@@ -107,7 +100,6 @@ class RegisterForm extends Component {
             Submit
           </Button>
         </Form>
-      </div>
     )
   }
 } 

--- a/src/user/RegisterForm.js
+++ b/src/user/RegisterForm.js
@@ -44,25 +44,6 @@ class RegisterForm extends Component {
     this.props.onSubmission(data);
   }
 
-  async register(payload) {
-    try {
-      const response = await axios.post(process.env.REACT_APP_API_URL + '/auth/register', payload);
-      const token = response.data.token;
-
-      localStorage.setItem('token', token);
-
-      this.setState({
-        authenticated: true,
-        errorResponse: '',
-      });
-
-    } catch(exception) {   
-      this.setState({
-        errorResponse: exception.response.data.error,
-      })
-    }; 
-  }
-
   handleFormChange(e) {
     const {currentTarget} = e;
     this.setState({
@@ -75,15 +56,15 @@ class RegisterForm extends Component {
         <Form className="register-form" onSubmit={this.submitHandler}>
           <Form.Group controlId="formFirstName">
             <Form.Label>First Name</Form.Label>
-            <Form.Control type="text" name="firstName" onChange={this.handleFormChange} required />
+            <Form.Control type="text" name="firstName" value={this.props.firstName} onChange={this.handleFormChange} required />
           </Form.Group>
           <Form.Group controlId="formLastName">
             <Form.Label>Last Name</Form.Label>
-            <Form.Control type="text" name="lastName" onChange={this.handleFormChange} required />
+            <Form.Control type="text" name="lastName" value={this.props.lastName} onChange={this.handleFormChange} required />
           </Form.Group>
           <Form.Group controlId="formEmail">
             <Form.Label>Email</Form.Label>
-            <Form.Control type="email" name="email" onChange={this.handleFormChange} required />
+            <Form.Control type="email" name="email" value={this.props.email} onChange={this.handleFormChange} required />
           </Form.Group>
           <Form.Group controlId="formPassword">
             <Form.Label>Password</Form.Label>

--- a/src/user/RegisterPage.css
+++ b/src/user/RegisterPage.css
@@ -1,0 +1,14 @@
+.form-component-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border: .2rem solid #ececec;
+  padding: 1em;
+  width: 50%;
+  border-radius: 10px;
+}
+
+.alertStyle {
+  width: 90%;
+}

--- a/src/user/RegisterPage.js
+++ b/src/user/RegisterPage.js
@@ -1,7 +1,12 @@
+// The Register Page is the page where people register for the site
+// It imports all the current styles and adds the register form component (which is completely modular)
+// it handles the logic of posting from the front-end to the back-end and receives responses
+// which are displayed onto the screen.
+
 import React, {Component} from 'react';
 import {Alert} from 'react-bootstrap';
 import axios from 'axios';
-import './UserEditPage.css';
+import './RegisterPage.css';
 import RegisterForm from './RegisterForm';
 
 class RegisterPage extends Component {
@@ -48,9 +53,6 @@ class RegisterPage extends Component {
         </Alert>}
         <RegisterForm 
         onSubmission={this.register} 
-        firstName="Joe" 
-        lastName="West" 
-        email="joe.west@ccpd.gov"
         submitButton="Register" 
         />
       </div>

--- a/src/user/RegisterPage.js
+++ b/src/user/RegisterPage.js
@@ -4,16 +4,16 @@ import axios from 'axios';
 import './UserEditPage.css';
 import RegisterForm from './RegisterForm';
 
-class UserEditPage extends Component {
+class RegisterPage extends Component {
   constructor(props) {
     super(props);
 
     this.state = {authenticated: false, errorResponse: {}};
 
-    this.editDetailsHandler = this.editDetailsHandler.bind(this);
+    this.register = this.register.bind(this);
   }
 
-  async editDetailsHandler(payload) {
+  async register(payload) {
     try {
       const response = await axios.post(process.env.REACT_APP_API_URL + '/auth/register', payload);
       const {status: responseStatus} = response;
@@ -47,15 +47,15 @@ class UserEditPage extends Component {
             this.state.requirements.map((requirement, idx) => <li key={idx}>{requirement}</li>)}
         </Alert>}
         <RegisterForm 
-        onSubmission={this.editDetailsHandler} 
+        onSubmission={this.register} 
         firstName="Joe" 
         lastName="West" 
         email="joe.west@ccpd.gov"
-        submitButton="Edit Details" 
+        submitButton="Register" 
         />
       </div>
     );
   };
 }
 
-export default UserEditPage;
+export default RegisterPage;

--- a/src/user/UserEditPage.css
+++ b/src/user/UserEditPage.css
@@ -1,0 +1,14 @@
+.form-component-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border: .2rem solid #ececec;
+  padding: 1em;
+  width: 50%;
+  border-radius: 10px;
+}
+
+.alertStyle {
+  width: 90%;
+}

--- a/src/user/UserEditPage.js
+++ b/src/user/UserEditPage.js
@@ -16,18 +16,23 @@ class UserEditPage extends Component {
   async editDetailsHandler(payload) {
     try {
       const response = await axios.post(process.env.REACT_APP_API_URL + '/auth/register', payload);
-      const token = response.data.token;
+      const {status: responseStatus} = response;
+      const {message : responseMessage, token} = response.data;
 
       localStorage.setItem('token', token);
 
       this.setState({
         authenticated: true,
-        errorResponse: '',
+        responseMessage,
+        responseStatus,
+        requirements: '',
       });
 
-    } catch(exception) {   
+    } catch(exception) {
+      const {message : responseMessage, requirements} = exception.response.data.error;
       this.setState({
-        errorResponse: exception.response.data.error,
+        responseMessage,
+        requirements
       })
     }; 
   }
@@ -35,11 +40,11 @@ class UserEditPage extends Component {
   render() {
     return (
       <div className="form-component-container">
-        {this.state.errorResponse.message && 
-        <Alert variant="danger" className="alertStyle">
-          {this.state.errorResponse.message}
-          {this.state.errorResponse.requirements && 
-            this.state.errorResponse.requirements.map((requirement, idx) => <li key={idx}>{requirement}</li>)}
+        {this.state.responseMessage && 
+        <Alert variant={this.state.responseStatus === 201 ? "success" : "danger"} className="alertStyle">
+          {this.state.responseMessage}
+          {this.state.requirements && 
+            this.state.requirements.map((requirement, idx) => <li key={idx}>{requirement}</li>)}
         </Alert>}
         <RegisterForm 
         onSubmission={this.editDetailsHandler} 

--- a/src/user/UserEditPage.js
+++ b/src/user/UserEditPage.js
@@ -1,5 +1,11 @@
+// The User Edit Page is the page where the user edits their current details on file
+// It imports all the current styles and adds the register form component (which is reusable for the edit page)
+// it handles the logic of posting from the front-end to the back-end and receives responses
+// which are displayed onto the screen.
+
 import React, {Component} from 'react';
 import {Alert} from 'react-bootstrap';
+// eslint-disable-next-line
 import axios from 'axios';
 import './UserEditPage.css';
 import RegisterForm from './RegisterForm';
@@ -11,30 +17,15 @@ class UserEditPage extends Component {
     this.state = {authenticated: false, errorResponse: {}};
 
     this.editDetailsHandler = this.editDetailsHandler.bind(this);
+    this.fetchDetails = this.fetchDetails.bind(this);
   }
 
   async editDetailsHandler(payload) {
-    try {
-      const response = await axios.post(process.env.REACT_APP_API_URL + '/auth/register', payload);
-      const {status: responseStatus} = response;
-      const {message : responseMessage, token} = response.data;
+    // Method to post data
+  }
 
-      localStorage.setItem('token', token);
-
-      this.setState({
-        authenticated: true,
-        responseMessage,
-        responseStatus,
-        requirements: '',
-      });
-
-    } catch(exception) {
-      const {message : responseMessage, requirements} = exception.response.data.error;
-      this.setState({
-        responseMessage,
-        requirements,
-      })
-    }; 
+  async fetchDetails() {
+    // Method to fetch details of the user
   }
 
   render() {
@@ -48,9 +39,9 @@ class UserEditPage extends Component {
         </Alert>}
         <RegisterForm 
         onSubmission={this.editDetailsHandler} 
-        firstName="Joe" 
-        lastName="West" 
-        email="joe.west@ccpd.gov"
+        firstName="" 
+        lastName="" 
+        email=""
         submitButton="Edit Details" 
         />
       </div>

--- a/src/user/UserEditPage.js
+++ b/src/user/UserEditPage.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, {Component} from 'react';
 import {Alert} from 'react-bootstrap';
-import "./SignInForm.css";
+import './RegisterForm.css';
 import axios from 'axios';
+import RegisterForm from './RegisterForm';
 
 class UserEditPage extends Component {
   constructor(props) {
@@ -9,22 +10,38 @@ class UserEditPage extends Component {
 
     this.state = {authenticated: false, errorResponse: {}};
 
-    this.register = this.register.bind(this);
+    this.editDetailsHandler = this.editDetailsHandler.bind(this);
   }
 
-  login(payload) {
+  async editDetailsHandler(payload) {
+    try {
+      const response = await axios.post(process.env.REACT_APP_API_URL + '/auth/register', payload);
+      const token = response.data.token;
 
+      localStorage.setItem('token', token);
+
+      this.setState({
+        authenticated: true,
+        errorResponse: '',
+      });
+
+    } catch(exception) {   
+      this.setState({
+        errorResponse: exception.response.data.error,
+      })
+    }; 
   }
 
   render() {
     return (
       <div className="form-component-container">
-        {(this.state.errorResponse.message || this.state.authenticated) && 
-        <Alert variant={`${this.state.authenticated ? "success" : "danger"}`}>
+        {this.state.errorResponse.message && 
+        <Alert variant="danger" className="alertStyle">
           {this.state.errorResponse.message}
-          {this.state.successMessage}
-        </Alert>}  
-        
+          {this.state.errorResponse.requirements && 
+            this.state.errorResponse.requirements.map((requirement, idx) => <li key={idx}>{requirement}</li>)}
+        </Alert>}
+        <RegisterForm onSubmission={this.editDetailsHandler} />        
       </div>
     );
   };

--- a/src/user/UserEditPage.js
+++ b/src/user/UserEditPage.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {Alert} from 'react-bootstrap';
-import './UserEditPage.css';
 import axios from 'axios';
+import './UserEditPage.css';
 import RegisterForm from './RegisterForm';
 
 class UserEditPage extends Component {

--- a/src/user/UserEditPage.js
+++ b/src/user/UserEditPage.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import {Alert} from 'react-bootstrap';
+import "./SignInForm.css";
+import axios from 'axios';
+
+class UserEditPage extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {authenticated: false, errorResponse: {}};
+
+    this.register = this.register.bind(this);
+  }
+
+  login(payload) {
+
+  }
+
+  render() {
+    return (
+      <div className="form-component-container">
+        {(this.state.errorResponse.message || this.state.authenticated) && 
+        <Alert variant={`${this.state.authenticated ? "success" : "danger"}`}>
+          {this.state.errorResponse.message}
+          {this.state.successMessage}
+        </Alert>}  
+        
+      </div>
+    );
+  };
+}
+
+export default UserEditPage;

--- a/src/user/UserEditPage.js
+++ b/src/user/UserEditPage.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {Alert} from 'react-bootstrap';
-import './RegisterForm.css';
+import './UserEditPage.css';
 import axios from 'axios';
 import RegisterForm from './RegisterForm';
 
@@ -41,7 +41,12 @@ class UserEditPage extends Component {
           {this.state.errorResponse.requirements && 
             this.state.errorResponse.requirements.map((requirement, idx) => <li key={idx}>{requirement}</li>)}
         </Alert>}
-        <RegisterForm onSubmission={this.editDetailsHandler} />        
+        <RegisterForm 
+        onSubmission={this.editDetailsHandler} 
+        firstName="David" 
+        lastName="Peterson" 
+        email="david.peterson@gmail.com" 
+        />        
       </div>
     );
   };


### PR DESCRIPTION
So I was thinking about the pages that we have, especially the Register and Edit User (which I believe is in the Create User Settings Page [#48](https://github.com/en3on/octagon-solutions/issues/48). The register form will essentially be copied for both the Register and Edit User which isn't DRY at all, that's some ugly ass tech debt. 

Instead, I want to refactor the register form so that a prop can be passed down to it that is a callback to its own submission function (in the parent user settings page), this prop can be accessed in the register component, and upon submission will hit its own submitHandler() function, which will wrap the relevant state fields and send the information to the parent submission function, allowing the child component (RegisterForm) to be isolated completely and be reused in both pages (as one will hit a post at one endpoint and a put/patch on the edit). 

I will implement this and show the proposed changes.